### PR TITLE
fix travis condition check

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,7 +8,7 @@ use My::Utility qw(check_config_script check_prebuilt_binaries check_prereqs_lib
 
 use Getopt::Long;
 my ($ans, $travis)   = '';
-GetOptions (  "travis"  => \$travis)  ;
+GetOptions("travis" => \$travis);
 
 print "Welcome to Alien::SDL2 module installation\n";
 print "------------------------------------------\n";
@@ -192,7 +192,7 @@ else {
   }
 
   # select option '1' for travis
-  if ($travis == 1) {
+  if (defined $travis && $travis == 1) {
       $ans = 1;
       #set 'travis' var for inc/My/Builder.pm
       $build->notes( 'travis', '1' );


### PR DESCRIPTION
$travis may be undef after GetOptions("travis" => \$travis);
Will cause errors like this during build:

	Unknown option: installdirs
	Welcome to Alien::SDL2 module installation
	------------------------------------------
	checking operating system... MSWin32
	checking for gcc... yes
	checking build system type... MSWin32-x64-multi-thread
	checking platform specific module... using 'My::Builder::Windows'
	checking for config script... no
	checking for prebuilt binaries... yes, 1 option(s)
	Use of uninitialized value $travis in numeric eq (==) at Build.PL line 195.